### PR TITLE
Add copyright headers to all Go files

### DIFF
--- a/cmd/padlock/main.go
+++ b/cmd/padlock/main.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // Package main provides the command-line interface for the padlock cryptographic system.
 //
 // Padlock is a K-of-N threshold one-time-pad cryptographic system that provides

--- a/pkg/file/adapter.go
+++ b/pkg/file/adapter.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/collection.go
+++ b/pkg/file/collection.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // Package file provides the file system operations for the padlock cryptographic system.
 //
 // This package handles all interactions with the file system, including:

--- a/pkg/file/collection_test.go
+++ b/pkg/file/collection_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/compress.go
+++ b/pkg/file/compress.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/compress_test.go
+++ b/pkg/file/compress_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/directory.go
+++ b/pkg/file/directory.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/directory_test.go
+++ b/pkg/file/directory_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/format.go
+++ b/pkg/file/format.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // Package file provides utilities for file and directory management in the padlock system.
 //
 // This package implements various file handling operations critical to the padlock

--- a/pkg/file/format_test.go
+++ b/pkg/file/format_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/serialize.go
+++ b/pkg/file/serialize.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/zip.go
+++ b/pkg/file/zip.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/file/zip_test.go
+++ b/pkg/file/zip_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package file
 
 import (

--- a/pkg/pad/pad.go
+++ b/pkg/pad/pad.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // Package pad implements a secure K-of-N threshold one-time-pad cryptographic scheme.
 //
 // This package provides the core cryptographic functionality of the padlock system,

--- a/pkg/pad/pad_test.go
+++ b/pkg/pad/pad_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package pad
 
 import (

--- a/pkg/pad/rng.go
+++ b/pkg/pad/rng.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // This file contains the core random number generation functionality
 // for the padlock system.
 

--- a/pkg/pad/rng_providers.go
+++ b/pkg/pad/rng_providers.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // This file contains implementations of various random number generator providers
 // used by the padlock system.
 

--- a/pkg/pad/rng_providers_test.go
+++ b/pkg/pad/rng_providers_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package pad
 
 import (

--- a/pkg/pad/rng_test.go
+++ b/pkg/pad/rng_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package pad
 
 import (

--- a/pkg/pad/test_rng.go
+++ b/pkg/pad/test_rng.go
@@ -1,1 +1,3 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package pad

--- a/pkg/padlock/padlock.go
+++ b/pkg/padlock/padlock.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 // Package padlock implements the high-level operations for encoding and decoding files
 // using the K-of-N threshold one-time-pad cryptographic scheme.
 //

--- a/pkg/padlock/padlock_test.go
+++ b/pkg/padlock/padlock_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package padlock
 
 import (

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package trace
 
 import (

--- a/pkg/trace/trace_test.go
+++ b/pkg/trace/trace_test.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Ray Ozzie and his Mom. All rights reserved.
+
 package trace
 
 import (


### PR DESCRIPTION
## Summary
- Added copyright headers for Ray Ozzie and his Mom to all Go source files in the project
- Applied the standard header format: // Copyright 2025 Ray Ozzie and his Mom. All rights reserved.

## Test plan
- No functional code changes, only comments were added
- Standard Go toolchain will still compile all files correctly

🤖 Generated with [Claude Code](https://claude.ai/code)